### PR TITLE
Remove nightly requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["strip"]
-
 [package]
 name = "histdb-rs"
 version = "0.1.0"
@@ -41,4 +39,3 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 codegen-units = 1
 lto = true
 panic = 'abort'
-strip = "symbols"

--- a/README.md
+++ b/README.md
@@ -25,19 +25,7 @@ Has pretty much the same feature set as zsh-histdb:
 
 ## Installation
 
-Currently you need nightly to build histdb-rs. We are using the strip
-functionality to decrease the binary size automatically.
-
-```
-cargo +nightly install --path .
-```
-
-Or install it from crates.io
-```
-cargo +nightly install histdb-rs
-```
-
-After that you need to start the server. This might change in the future.
+You need to start the server. This might change in the future.
 
 ```
 histdb-rs server


### PR DESCRIPTION
The file size without stripping symbols is only `2.7M` so I don't feel like having the nightly requirement is worth it. 