### PR TITLE
#10 option to remove failed command

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
             override: true
 
       - name: Run clippy
-        run: cargo clippy --verbose
+        run: cargo clippy --verbose -- -D warnings -D clippy::dbg_macro -D clippy::todo
 
   test-linux:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
 ## 1.1.0 [UNRELEASED]
-* Add flag `--session` which allows to filter entries by the given session. The
-session of a history entry can be found using `--show-session`.
+* Add flag `--session`. Allows to filter entries by the given
+  session. The session of a history entry can be found using
+  `--show-session`.
+* Add flag `--filter-failed`. Enables filtering of failed commands
+  when listing the history. Will filter out all commands that had a
+  return code that is not 0.
+* Add option `--find-status`. When specified will find all commands
+  with the given return code.
 
 ## 1.0.0 [2021-06-01]
 * No big changes just updated the dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ thiserror = "1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [profile.release]
-codegen-units = 1
-lto = true
-panic = 'abort'
+lto = "fat"
+panic = "abort"
+opt-level = 3

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -20,7 +20,7 @@ pub struct Entry {
     pub hostname: String,
     pub command: String,
     pub pwd: PathBuf,
-    pub result: usize,
+    pub result: u16,
     pub session_id: Uuid,
     pub user: String,
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -93,7 +93,7 @@ impl CommandStart {
 pub struct CommandFinished {
     pub session_id: Uuid,
     pub time_stamp: DateTime<Utc>,
-    pub result: usize,
+    pub result: u16,
 }
 
 impl CommandFinished {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -238,6 +238,10 @@ struct DefaultArgs {
     /// Disable printing of header
     #[structopt(long)]
     hide_header: bool,
+
+    /// Filter out failed commands (return code not 0)
+    #[structopt(long)]
+    filter_failed: bool,
 }
 
 #[derive(StructOpt, Debug)]
@@ -308,6 +312,7 @@ impl Opt {
         let session_filter = self.default_args.session;
         let no_subdirs = self.default_args.no_subdirs;
         let command_text = self.default_args.command_text;
+        let filter_failed = self.default_args.filter_failed;
 
         let format = !self.default_args.disable_formatting;
         let duration = Display::should_show(self.default_args.show_duration);
@@ -324,7 +329,8 @@ impl Opt {
                     .hostname(hostname, all_hosts)?
                     .count(entries_count)
                     .command(command, command_text)
-                    .session(session_filter);
+                    .session(session_filter)
+                    .filter_failed(filter_failed);
 
                 let display = TableDisplay {
                     format,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -242,6 +242,10 @@ struct DefaultArgs {
     /// Filter out failed commands (return code not 0)
     #[structopt(long)]
     filter_failed: bool,
+
+    /// Find commands with the given return code
+    #[structopt(long)]
+    find_status: Option<u16>,
 }
 
 #[derive(StructOpt, Debug)]
@@ -313,6 +317,7 @@ impl Opt {
         let no_subdirs = self.default_args.no_subdirs;
         let command_text = self.default_args.command_text;
         let filter_failed = self.default_args.filter_failed;
+        let find_status = self.default_args.find_status;
 
         let format = !self.default_args.disable_formatting;
         let duration = Display::should_show(self.default_args.show_duration);
@@ -330,7 +335,8 @@ impl Opt {
                     .count(entries_count)
                     .command(command, command_text)
                     .session(session_filter)
-                    .filter_failed(filter_failed);
+                    .filter_failed(filter_failed)
+                    .find_status(find_status);
 
                 let display = TableDisplay {
                     format,

--- a/src/run/import.rs
+++ b/src/run/import.rs
@@ -200,7 +200,7 @@ pub fn histfile(import_file: impl AsRef<Path>, data_dir: PathBuf) -> Result<(), 
     #[derive(Debug)]
     struct HistfileEntry {
         time_finished: DateTime<Utc>,
-        result: usize,
+        result: u16,
         command: String,
     }
 
@@ -208,7 +208,7 @@ pub fn histfile(import_file: impl AsRef<Path>, data_dir: PathBuf) -> Result<(), 
     let reader = std::io::BufReader::new(histfile);
 
     let mut acc_time_finished: Option<DateTime<Utc>> = None;
-    let mut acc_result: Option<usize> = None;
+    let mut acc_result: Option<u16> = None;
     let mut acc_command: Option<String> = None;
     let mut multiline_command = false;
 

--- a/src/store/filter.rs
+++ b/src/store/filter.rs
@@ -21,6 +21,7 @@ pub struct Filter {
     command_text: Option<Regex>,
     count: usize,
     session: Option<Regex>,
+    filter_failed: bool,
 }
 
 impl Filter {
@@ -101,6 +102,7 @@ impl Filter {
                     .as_ref()
                     .map_or(true, |regex| regex.is_match(&entry.session_id.to_string()))
             })
+            .filter(|entry| !self.filter_failed || entry.result == 0)
             .collect();
 
         if self.count > 0 {
@@ -112,6 +114,13 @@ impl Filter {
 
     pub fn session(self, session: Option<Regex>) -> Self {
         Self { session, ..self }
+    }
+
+    pub fn filter_failed(self, filter_failed: bool) -> Self {
+        Self {
+            filter_failed,
+            ..self
+        }
     }
 
     fn filter_command(entry_command: &str, command: &str) -> bool {

--- a/src/store/filter.rs
+++ b/src/store/filter.rs
@@ -14,14 +14,15 @@ pub enum Error {
 
 #[derive(Debug, Default)]
 pub struct Filter {
-    hostname: Option<String>,
-    directory: Option<PathBuf>,
-    command: Option<String>,
-    no_subdirs: bool,
-    command_text: Option<Regex>,
-    count: usize,
-    session: Option<Regex>,
-    filter_failed: bool,
+    pub hostname: Option<String>,
+    pub directory: Option<PathBuf>,
+    pub command: Option<String>,
+    pub no_subdirs: bool,
+    pub command_text: Option<Regex>,
+    pub count: usize,
+    pub session: Option<Regex>,
+    pub filter_failed: bool,
+    pub find_status: Option<u16>,
 }
 
 impl Filter {
@@ -103,6 +104,17 @@ impl Filter {
                     .map_or(true, |regex| regex.is_match(&entry.session_id.to_string()))
             })
             .filter(|entry| !self.filter_failed || entry.result == 0)
+            .filter(|entry| {
+                self.find_status
+                    .and_then(|find_status| {
+                        if find_status == entry.result {
+                            None
+                        } else {
+                            Some(())
+                        }
+                    })
+                    .is_none()
+            })
             .collect();
 
         if self.count > 0 {
@@ -133,6 +145,13 @@ impl Filter {
                     .map_or(false, |entry_command| entry_command == command)
             })
             .any(|has_command| has_command)
+    }
+
+    pub fn find_status(self, find_status: Option<u16>) -> Self {
+        Self {
+            find_status,
+            ..self
+        }
     }
 }
 


### PR DESCRIPTION
* Add option `--filter-failed` \
  Enabled filtering of failed commands when listing the history. Will filter out all commands that had a return code that is not 0.

* Add argument `--find-status` \
  When specified will find all commands with the given return code.

Fixes #10.