### PR TITLE
Ignore command starting with a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   return code that is not 0.
 * Add option `--find-status`. When specified will find all commands
   with the given return code.
+* Ignore commands starting with ' ' (space). This should make it
+  easier to not record sensitive commands.
 
 ## 1.0.0 [2021-06-01]
 * No big changes just updated the dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 * Add option `--find-status`. When specified will find all commands
   with the given return code.
 * Ignore commands starting with ' ' (space). This should make it
-  easier to not record sensitive commands.
+  easier to not record sensitive commands. This is configurable in a
+  configuration file with the option `ignore_space`. By default this
+  is enabled.
 
 ## 1.0.0 [2021-06-01]
 * No big changes just updated the dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   easier to not record sensitive commands. This is configurable in a
   configuration file with the option `ignore_space`. By default this
   is enabled.
+* Add configuration option `log_level` to change the default log level
+  to run under.
 
 ## 1.0.0 [2021-06-01]
 * No big changes just updated the dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "sled",
  "structopt",
  "thiserror",
+ "toml",
  "uuid",
 ]
 
@@ -940,6 +941,15 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ flume = "0.10"
 glob = "0.3"
 hostname = "0.3"
 humantime = "2"
-log = "0.4"
+log = { version = "0.4", features = ["serde"] }
 pretty_env_logger = "0.4"
 regex = "1"
 rusqlite = { version = "0.25", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1", features = ["derive"] }
 sled = "0.34"
 structopt = "0.3"
 thiserror = "1"
+toml = "0.5"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -205,6 +205,22 @@ After that you can configure origins and start syncing the files between
 machines. There is no autocommit/autosync implemented as we don't want to have
 commits for each command run. This could be changed in the future.
 
+## Configuration
+
+There is also a way to configure `histdb-rs`. By default the configuration is stored under `$HOME/.config/histdb-rs/config.toml`. A different path can be specified using the `--config-path` option.
+
+The default configuration looks like this:
+
+```toml
+# When true will not save commands that start with a space.
+# Default: true
+ignore_space = true
+
+# The log level to run under.
+# Default: Warn
+log_level = "Warn"
+```
+
 ## Import
 
 ### zsh-histdb

--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,7 @@
 # When true will not save commands that start with a space.
 # Default: true
 ignore_space = true
+
+# The log level to run under.
+# Default: Warn
+log_level = "Warn"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+# When true will not save commands that start with a space.
+# Default: true
+ignore_space = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,42 @@
+use log::debug;
+use std::path::Path;
+use thiserror::Error;
+
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("can not read config file: {0}")]
+    ReadFile(std::io::Error),
+
+    #[error("can not parse config file: {0}")]
+    ParseConfig(toml::de::Error),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub ignore_space: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { ignore_space: true }
+    }
+}
+
+impl Config {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
+        if !path.as_ref().is_file() {
+            debug!("no config file found using default");
+            return Ok(Self::default());
+        }
+
+        let config_data = std::fs::read(path).map_err(Error::ReadFile)?;
+        let config = toml::de::from_slice(&config_data).map_err(Error::ParseConfig)?;
+
+        Ok(config)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,11 @@
-use log::debug;
+use log::{
+    debug,
+    LevelFilter,
+};
 use std::path::Path;
 use thiserror::Error;
 
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use serde::Deserialize;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -16,14 +16,22 @@ pub enum Error {
     ParseConfig(toml::de::Error),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
+#[serde(default)]
 pub struct Config {
+    /// Then true disables recording commands that start with a space
     pub ignore_space: bool,
+
+    /// The log level to run under
+    pub log_level: LevelFilter,
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self { ignore_space: true }
+        Self {
+            ignore_space: true,
+            log_level: LevelFilter::Warn,
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 mod client;
+mod config;
 mod entry;
 mod message;
 mod opt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,6 @@ use opt::Opt;
 use structopt::StructOpt;
 
 fn main() {
-    if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "info");
-    }
-    pretty_env_logger::init();
-
     let opt = Opt::from_args();
 
     if let Err(err) = opt.run() {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -348,6 +348,11 @@ impl Opt {
         let session = Display::should_show(self.default_args.show_session);
         let status = Display::should_show(self.default_args.show_status);
 
+        if std::env::var_os("RUST_LOG").is_none() {
+            std::env::set_var("RUST_LOG", config.log_level.as_str());
+        }
+        pretty_env_logger::init();
+
         sub_command.map_or_else(
             || {
                 let filter = Filter::default()

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config,
     run,
     run::{
         Display,
@@ -98,6 +99,14 @@ fn default_socket_path() -> Result<String, Error> {
     Ok(socket_path.to_string_lossy().to_string())
 }
 
+fn default_config_path() -> Result<String, Error> {
+    let project_dir = project_dir();
+
+    let socket_path = project_dir?.config_dir().join("config.toml");
+
+    Ok(socket_path.to_string_lossy().to_string())
+}
+
 #[derive(StructOpt, Debug)]
 struct ZSHAddHistory {
     #[structopt(flatten)]
@@ -156,6 +165,13 @@ struct Socket {
     /// Path to the socket for communication with the server
     #[structopt(short, long, env = "HISTDBRS_SOCKET_PATH", default_value = into_str!(get_default_or_fail(default_socket_path)))]
     socket_path: PathBuf,
+}
+
+#[derive(StructOpt, Debug)]
+struct Config {
+    /// Path to the socket for communication with the server
+    #[structopt(long, env = "HISTDBRS_CONFIG_PATH", default_value = into_str!(get_default_or_fail(default_config_path)))]
+    config_path: PathBuf,
 }
 
 #[derive(StructOpt, Debug)]
@@ -246,6 +262,9 @@ struct DefaultArgs {
     /// Find commands with the given return code
     #[structopt(long)]
     find_status: Option<u16>,
+
+    #[structopt(flatten)]
+    config: Config,
 }
 
 #[derive(StructOpt, Debug)]
@@ -318,6 +337,8 @@ impl Opt {
         let command_text = self.default_args.command_text;
         let filter_failed = self.default_args.filter_failed;
         let find_status = self.default_args.find_status;
+        let config = config::Config::open(self.default_args.config.config_path)
+            .map_err(run::Error::ReadConfig)?;
 
         let format = !self.default_args.disable_formatting;
         let duration = Display::should_show(self.default_args.show_duration);
@@ -353,7 +374,7 @@ impl Opt {
             },
             |sub_command| match sub_command {
                 SubCommand::ZSHAddHistory(o) => {
-                    run::zsh_add_history(o.command, o.socket_path.socket_path)
+                    run::zsh_add_history(&config, o.command, o.socket_path.socket_path)
                 }
                 SubCommand::Server(o) => {
                     run::server(o.cache_path, o.socket_path.socket_path, o.data_dir.data_dir)

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,6 +2,7 @@ pub mod import;
 
 use crate::{
     client,
+    config,
     entry::Entry,
     message,
     message::{
@@ -70,6 +71,9 @@ pub enum Error {
 
     #[error("can not import entries: {0}")]
     Import(import::Error),
+
+    #[error("can not read configuration file: {0}")]
+    ReadConfig(config::Error),
 }
 
 #[derive(Debug)]
@@ -279,9 +283,13 @@ pub fn default_format(display: &TableDisplay, entries: Vec<Entry>) -> Result<(),
     Ok(())
 }
 
-pub fn zsh_add_history(command: String, socket_path: PathBuf) -> Result<(), Error> {
-    if command.starts_with(' ') {
-        debug!("not recording a command starting with a space")
+pub fn zsh_add_history(
+    config: &config::Config,
+    command: String,
+    socket_path: PathBuf,
+) -> Result<(), Error> {
+    if config.ignore_space && command.starts_with(' ') {
+        debug!("not recording a command starting with a space");
     } else {
         let data = CommandStart::from_env(command)?;
         client::new(socket_path).send(&Message::CommandStart(data))?;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -27,6 +27,7 @@ use comfy_table::{
     Cell,
     Table,
 };
+use log::debug;
 use std::{
     convert::TryInto,
     io::Write,
@@ -279,9 +280,12 @@ pub fn default_format(display: &TableDisplay, entries: Vec<Entry>) -> Result<(),
 }
 
 pub fn zsh_add_history(command: String, socket_path: PathBuf) -> Result<(), Error> {
-    let data = CommandStart::from_env(command)?;
-
-    client::new(socket_path).send(&Message::CommandStart(data))?;
+    if command.starts_with(' ') {
+        debug!("not recording a command starting with a space")
+    } else {
+        let data = CommandStart::from_env(command)?;
+        client::new(socket_path).send(&Message::CommandStart(data))?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
* Ignore commands starting with ' ' (space). This should make it
  easier to not record sensitive commands.

Fixes #9.