### PR TITLE
Don't print an error if the pipe is closed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,14 @@ use structopt::StructOpt;
 fn main() {
     let opt = Opt::from_args();
 
-    if let Err(err) = opt.run() {
-        error!("{}", err);
+    match opt.run() {
+        Err(run::Error::WriteStdout(io_err)) => {
+            // If pipe is closed we can savely ignore that error
+            if io_err.kind() == std::io::ErrorKind::BrokenPipe {}
+        }
+
+        Err(err) => error!("{}", err),
+
+        Ok(_) => (),
     }
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -182,6 +182,7 @@ pub fn default_no_format(display: &TableDisplay, entries: Vec<Entry>) -> Result<
         handle
             .write_all(header.join("\t").as_bytes())
             .map_err(Error::WriteStdout)?;
+
         handle.write_all(b"\n").map_err(Error::WriteStdout)?;
     }
 
@@ -212,6 +213,7 @@ pub fn default_no_format(display: &TableDisplay, entries: Vec<Entry>) -> Result<
         handle
             .write_all(row.join("\t").as_bytes())
             .map_err(Error::WriteStdout)?;
+
         handle.write_all(b"\n").map_err(Error::WriteStdout)?;
     }
 


### PR DESCRIPTION
Fixes #19.